### PR TITLE
Fix convenience creation methods

### DIFF
--- a/YYCache/YYCache.m
+++ b/YYCache/YYCache.m
@@ -43,11 +43,11 @@
 }
 
 + (instancetype)cacheWithName:(NSString *)name {
-	return [[YYCache alloc] initWithName:name];
+    return [[self alloc] initWithName:name];
 }
 
 + (instancetype)cacheWithPath:(NSString *)path {
-    return [[YYCache alloc] initWithPath:path];
+    return [[self alloc] initWithPath:path];
 }
 
 - (BOOL)containsObjectForKey:(NSString *)key {


### PR DESCRIPTION
Hi, I found a little problem during subclassing YYCache.

Consider:

``` obj-c
// .h file
@interface MyCache : YYCache

- (void)doSomething;

@end


// .m file
@implementation MyCache

- (void)doSomething {
    // code goes here
}

@end
```

``` obj-c
MyCache *cache = [MyCache cacheWithName:"cache-name"];
[cache doSomething]; // This line will raise an `unrecognized selector` exception.
```

The problem is that you declared that `+cacheWithName:` and `+cacheWithPath:` would return `instancetype`, but they returned `YYCache` instance actually.

This PR fixes the issue by making convience creation methods use the current class type instead of a hardcoded one.

Cheers! 🍻 
