### PR TITLE
Update podspec to support tvOS

### DIFF
--- a/YYCache.podspec
+++ b/YYCache.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/ibireme/YYCache'
   s.platform     = :ios, '6.0'
   s.ios.deployment_target = '6.0'
+  s.tvos.deployment_target = "9.0"
   s.source       = { :git => 'https://github.com/ibireme/YYCache.git', :tag => s.version.to_s }
   
   s.requires_arc = true


### PR DESCRIPTION
This is a minor change to make the YYCache library work with tvOS. It has been tested in production and works fine; all you need to do is advertise support in the podspec.