### PR TITLE
fix data race crash in memory cache

### DIFF
--- a/YYCache/YYMemoryCache.m
+++ b/YYCache/YYMemoryCache.m
@@ -402,8 +402,9 @@ static inline dispatch_queue_t YYMemoryCacheGetReleaseQueue() {
         node->_time = CACurrentMediaTime();
         [_lru bringNodeToHead:node];
     }
+    id value = node ? node->_value : nil;
     pthread_mutex_unlock(&_lock);
-    return node ? node->_value : nil;
+    return value;
 }
 
 - (void)setObject:(id)object forKey:(id)key {


### PR DESCRIPTION
发现一个YYMemoryCache中资源争用引发的崩溃，具体复现demo见这里：https://github.com/ddhjy/ReproduceDataRaceCrashForYYCache